### PR TITLE
Only do a status request if you have a trxId

### DIFF
--- a/src/Requests/Transactions.php
+++ b/src/Requests/Transactions.php
@@ -100,11 +100,17 @@ class Transactions extends AbstractRequest
         }
 
         // generate result
-        $transactionResponse = $this->get($trxId);
-        $transactionResponse->documentId = $documentId;
-        $transactionResponse->documentURL = $documentUrl;
-        $transactionResponse->issuerUrl = urldecode($issuerUrl);
-        $transactionResponse->invoiceNo = $invoiceNo;
+	    $transactionResponse = new Transaction();
+
+        if ($trxId)
+        {
+	        $transactionResponse = $this->get($trxId);
+        }
+
+	    $transactionResponse->documentId  = $documentId;
+	    $transactionResponse->documentURL = $documentUrl;
+	    $transactionResponse->issuerUrl   = urldecode($issuerUrl);
+	    $transactionResponse->invoiceNo   = $invoiceNo;
 
         // return result
         return $transactionResponse;


### PR DESCRIPTION
When using `ideal` as payment method, there doesn't have to be an `issuerid`, this way the customer can choose the bank on the Sisow page. Now when using iDEAL you get an error that only says `No transactionid`, which is correct because Sisow doesn't give you one when using iDEAL without an issuer ID.

This change takes into account in case Sisow doesn't give you a transaction ID. Would be even better if Sisow always gives you a transaction ID.